### PR TITLE
Fixing documentation build error: was linking to previous package name

### DIFF
--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -20,9 +20,9 @@ version = "0.0.4"
 
 [[ArrayInterface]]
 deps = ["LinearAlgebra", "Requires", "SparseArrays"]
-git-tree-sha1 = "a7110d4291700c0d9ddbeb5fa41c3b9c4659c2aa"
+git-tree-sha1 = "40990a6dfd617d2f7d1375e9d4b52d962c8d6dcf"
 uuid = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
-version = "2.13.3"
+version = "2.13.4"
 
 [[ArrayLayouts]]
 deps = ["Compat", "FillArrays", "LinearAlgebra", "SparseArrays"]
@@ -35,14 +35,6 @@ deps = ["Pkg"]
 git-tree-sha1 = "c30985d8821e0cd73870b17b0ed0ce6dc44cb744"
 uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 version = "1.3.0"
-
-[[UnitfulAstrodynamics]]
-deps = ["ComponentArrays", "DifferentialEquations", "LinearAlgebra", "Logging", "PhysicalConstants", "Plots", "Reexport", "Roots", "StaticArrays", "Unitful", "UnitfulAngles", "UnitfulAstro"]
-git-tree-sha1 = "6d127ceb1f27126434e227b1c49522933244785d"
-repo-rev = "main"
-repo-url = "https://github.com/cadojo/UnitfulAstrodynamics.jl"
-uuid = "673e7d9c-15b0-48d3-bce0-fab551f3a174"
-version = "0.1.0"
 
 [[BandedMatrices]]
 deps = ["ArrayLayouts", "FillArrays", "LinearAlgebra", "Random", "SparseArrays"]
@@ -119,9 +111,9 @@ version = "0.3.0"
 
 [[Compat]]
 deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "SHA", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
-git-tree-sha1 = "cf03b37436c6bc162e7c8943001568b4cad4bee3"
+git-tree-sha1 = "f76e41cf110de7176a657c72409e722cfc86fbb6"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "3.19.0"
+version = "3.20.0"
 
 [[CompilerSupportLibraries_jll]]
 deps = ["Libdl", "Pkg"]
@@ -595,9 +587,9 @@ uuid = "71a1bf82-56d0-4bbc-8a3c-48b961074391"
 version = "0.1.5"
 
 [[OffsetArrays]]
-git-tree-sha1 = "3fdfca8a532507d65f39ff0ad34fe81097a55337"
+git-tree-sha1 = "a416e2f267e2c8729f25bcaf1ce19d2893faf393"
 uuid = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
-version = "1.3.0"
+version = "1.3.1"
 
 [[Ogg_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -976,6 +968,14 @@ deps = ["Unitful", "UnitfulAngles"]
 git-tree-sha1 = "b154be4ca9610e9c9dbb9dba98b2bd750539630b"
 uuid = "6112ee07-acf9-5e0f-b108-d242c714bf9f"
 version = "1.0.1"
+
+[[UnitfulAstrodynamics]]
+deps = ["ComponentArrays", "DifferentialEquations", "LinearAlgebra", "Logging", "PhysicalConstants", "Plots", "Reexport", "Roots", "StaticArrays", "Unitful", "UnitfulAngles", "UnitfulAstro"]
+git-tree-sha1 = "cf7f0c07b73db3efdb71d163f69b00d34a8dee33"
+repo-rev = "main"
+repo-url = "https://github.com/cadojo/UnitfulAstrodynamics.jl"
+uuid = "673e7d9c-15b0-48d3-bce0-fab551f3a174"
+version = "0.5.0"
 
 [[VectorizationBase]]
 deps = ["CpuId", "Libdl", "LinearAlgebra"]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,3 +1,3 @@
 [deps]
-UnitfulAstrodynamics = "673e7d9c-15b0-48d3-bce0-fab551f3a174"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+UnitfulAstrodynamics = "673e7d9c-15b0-48d3-bce0-fab551f3a174"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,9 +2,9 @@ push!(LOAD_PATH,"../src/")
 using Documenter
 using UnitfulAstrodynamics
 
-makedocs(modules=[Astrodynamics],
+makedocs(modules=[UnitfulAstrodynamics],
     format=Documenter.HTML(),
-    sitename="Astrodynamics.jl",
+    sitename="UnitfulAstrodynamics.jl",
     pages=[
         "Home" => "index.md",
         "Overview" => Any[
@@ -34,7 +34,7 @@ makedocs(modules=[Astrodynamics],
 
 deploydocs(
     target = "build",
-    repo="github.com/cadojo/Astrodynamics.jl.git",
+    repo="github.com/cadojo/UnitfulAstrodynamics.jl.git",
     branch = "gh-pages",
     deps   = nothing,
     make   = nothing,


### PR DESCRIPTION
* Should remove all build / test / documentation problems
* Updates `docs/` with new package name